### PR TITLE
Use checkout v3 because of nodejs deprecation warning

### DIFF
--- a/.github/workflows/redocusaurus.yml
+++ b/.github/workflows/redocusaurus.yml
@@ -20,7 +20,7 @@ jobs:
     container: node:lts-alpine3.17
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Redoc build
         working-directory: ./docs
         run: |


### PR DESCRIPTION
Checkout v2 uses an old nodejs version so we upgrade to v3.