### PR TITLE
Add Terraform Kubernetes cluster example

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,5 @@
+# Terraform examples
+
+This directory contains examples for how to use the API with Terraform.
+
+* [Kubernetes cluster](./cluster/README.md)

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -1,0 +1,26 @@
+# Terraform Kubernetes cluster example
+
+How to create a Kubernetes cluster with Terraform:
+
+* Review and adjust the credentials in [providers.tf](./providers.tf).
+* Apply the module.
+
+	```bash
+	# configure the namespace which terraform should use
+	$ export TF_VAR_namespace=<your cockpit account name>
+	# have a look at the plan
+	$ terraform plan
+	# apply the module
+	$ terraform apply
+	# after apply is successful, output the kubeconfig into a file
+	$ terraform output -raw kubeconfig > kubeconfig.yaml
+	# you should be able to access the newly created cluster
+	$ KUBECONFIG=kubeconfig.yaml kubectl get ns
+	NAME              STATUS   AGE
+	default           Active   57s
+	kube-system       Active   56s
+	kube-public       Active   56s
+	kube-node-lease   Active   56s
+	# clean up after you are done
+	$ terraform destroy
+	```

--- a/terraform/cluster/cluster.tf
+++ b/terraform/cluster/cluster.tf
@@ -1,0 +1,108 @@
+resource "kubernetes_manifest" "sample_cluster" {
+  manifest = {
+    apiVersion = "infrastructure.nine.ch/v1alpha1"
+    kind       = "KubernetesCluster"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      forProvider = {
+        vcluster = {}
+        # for a full nke cluster:
+        # nke = {}
+        nodePools = []
+        location  = "nine-es34"
+      }
+      writeConnectionSecretToRef = {
+        name      = var.name
+        namespace = var.namespace
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+}
+
+resource "kubernetes_manifest" "sample_ksa" {
+  manifest = {
+    apiVersion = "iam.nine.ch/v1alpha1"
+    kind       = "KubernetesServiceAccount"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      forProvider = {
+        cluster = {
+          name = kubernetes_manifest.sample_cluster.object.metadata.name
+        }
+      }
+      writeConnectionSecretToRef = {
+        name      = "${var.name}-ksa"
+        namespace = var.namespace
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+}
+
+resource "kubernetes_manifest" "sample_kcrb" {
+  manifest = {
+    apiVersion = "iam.nine.ch/v1alpha1"
+    kind       = "KubernetesClustersRoleBinding"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      forProvider = {
+        role = "admin"
+        subjects = [{
+          kind = "ServiceAccount",
+          name = kubernetes_manifest.sample_ksa.object.metadata.name
+        }]
+        clusters = [
+          {
+            name = kubernetes_manifest.sample_cluster.object.metadata.name
+          }
+        ]
+      }
+    }
+  }
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+}
+
+data "kubernetes_secret_v1" "cluster_credentials" {
+  metadata {
+    name      = kubernetes_manifest.sample_ksa.object.spec.writeConnectionSecretToRef.name
+    namespace = kubernetes_manifest.sample_ksa.object.spec.writeConnectionSecretToRef.namespace
+  }
+  depends_on = [kubernetes_manifest.sample_kcrb]
+}
+
+output "kubeconfig" {
+  sensitive = true
+  value     = data.kubernetes_secret_v1.cluster_credentials.data.kubeconfig
+}
+
+output "host" {
+  sensitive = true
+  value     = yamldecode(data.kubernetes_secret_v1.cluster_credentials.data.kubeconfig).clusters.0.cluster.server
+}

--- a/terraform/cluster/providers.tf
+++ b/terraform/cluster/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}
+
+provider "kubernetes" {
+  # there are different options on how to authenticate the kubernetes provider with nineapis.ch
+  # 1. use the kubeconfig that `nctl auth login <account name>` generates:
+  config_path    = "~/.kube/config"
+  config_context = "nineapis.ch"
+  # 2. use a kubeconfig of an API service account `nctl get asa <name> --print-kubeconfig > asa.yaml`
+  # config_path    = "/path/to/asa.yaml"
+  # config_context = "nineapis.ch"
+  # 3. use the token of an API service account directly `nctl get asa <name> --print-token`
+  # host  = "https://nineapis.ch"
+  # token = "ey..."
+}

--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  default     = "tf-sample"
+  description = "name of the cluster and associated resources"
+}
+
+variable "namespace" {
+  default     = "<your cockpit account name>"
+  description = "namespace to create the resources in (matches cockpit account name)"
+}


### PR DESCRIPTION
This adds an example module to show how to create any API resource using Terraform.