### PR TITLE
feat: add constructor for MachineType

### DIFF
--- a/infrastructure/v1alpha1/machine_type.go
+++ b/infrastructure/v1alpha1/machine_type.go
@@ -1,0 +1,7 @@
+package v1alpha1
+
+// NewMachineType returns an unparsed machine type that can be used to
+// create/update objects. Parsing and validation is done server-side.
+func NewMachineType(name string) MachineType {
+	return MachineType{name: name}
+}


### PR DESCRIPTION
Since we can't export the internal parsing logic of the machine type, we instead add a very simple constructor that just sets the name. This should be enough for basic API usage to create/update resources which have a machine type.