### PR TITLE
add stringer method for the BuildpackStack type

### DIFF
--- a/apps/v1alpha1/type_funcs.go
+++ b/apps/v1alpha1/type_funcs.go
@@ -95,3 +95,8 @@ func (envs EnvVars) WithOrigin(origin ConfigOrigin) OriginEnvVarList {
 	}
 	return result
 }
+
+// String implements the stringer interface for a `BuildpackStack`.
+func (b BuildpackStack) String() string {
+	return string(b)
+}


### PR DESCRIPTION
This is quite handy when comparing to predefined constants.